### PR TITLE
Revert "Remove stretch from the distribution as it is no longer supported. (#27640)"

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -3,6 +3,8 @@
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
 release_platforms:
+  debian:
+  - stretch
   ubuntu:
   - bionic
 repositories:


### PR DESCRIPTION
To temporally support our software on melodic on Debian stretch, as a workaround we revert the PR 27640.

This reverts commit 087971b184e795d8934b6a9b8e0d12d95ef52359.